### PR TITLE
Wrap strings in double quotes

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -701,7 +701,7 @@ class AppEngineDeploy
             'env_variables:',
         ];
         foreach ($this->arr_env as $str_key => $mix_value) {
-            if ("{" === substr(trim($mix_value), 0, 1)){
+            if (is_string($mix_value)){
                 $mix_value = json_encode($mix_value);
             }
             $arr_lines[] = '  ' . $str_key . ': ' . $mix_value;


### PR DESCRIPTION
Extends #2 to wrap any strings in double quotes to remove ambiguity so it works correctly with strings representing objects, arrays or having special YAML characters (`:`, `{`, `}`, `[`, `]`, `,`, `&`, `*`, `#`, `?`, `|`, `-`, `<`, `>`, `='`, `!`, `%`, `@`, `\`) .
Note, it will preserve the type for other scalar types. See thread on slack (infrastructure channel) for more details